### PR TITLE
feat(sponsors): add Norsys as first sponsor 2020!

### DIFF
--- a/data/sponsors.yml
+++ b/data/sponsors.yml
@@ -1,0 +1,14 @@
+etoile:
+  - name: Norsys
+    logo: img/sponsors/2018/norsys.png
+    url_fr: http://www.norsys.fr/
+    url_en: http://www.norsys.fr/
+    description_fr: Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.
+    description_en: Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.
+partners:
+  - name: AlpesJUG
+    logo: img/partners/alpesjug.png
+    url_fr: http://alpesjug.fr/
+    url_en: http://alpesjug.fr/
+    description_fr: AlpesJug est le groupe des utilisateurs Java de la région grenobloise, et à l'origine du Snowcamp.
+    description_en: AlpesJug is the Java User Group of the Grenoble area, and the initiator of the Snowcamp conference.

--- a/layouts/partials/index.en.html
+++ b/layouts/partials/index.en.html
@@ -195,169 +195,234 @@
       </div>
     </div>
   </section>
-<section>
-  <div id="sponsors" class="snc-sponsors">
-    <div class="snc-inner-bg">
-      <div class="snc-inner">
-        <div class="container">
-          <div class="row">
-            <div class="col-xs-12 text-center">
-              <div class="snc-heading-area">
-                <h2 class="snc-heading">
-                  <span class="back-heading"><i class="fa fa-thumbs-up" aria-hidden="true"></i></span>
-                  <span class="heading">Sponsors 2020</span>
-                </h2>
-                <p class="text">
-                  To make a success of this adventure, we need you!
-                  </p>
+  <section>
+    <div id="sponsors" class="snc-sponsors">
+      <div class="snc-inner-bg">
+        <div class="snc-inner">
+          <div class="container">
+            <div class="row">
+              <div class="col-xs-12 text-center">
+                <div class="snc-heading-area">
+                  <h2 class="snc-heading">
+                    <span class="back-heading"><i class="fa fa-thumbs-up" aria-hidden="true"></i></span>
+                    <span class="heading">Sponsors 2020</span>
+                  </h2>
+                  <p class="text">
+                      They have already placed their trust to prepare 2020 edition together.
+                      Many thanks to our sponsors!
+                    </p>
+                </div>
               </div>
             </div>
+            {{ if isset .Site.Data.sponsors "chamois" }}
+            <div class="row">
+              <div class="col-xs-12">
+                <h3 class="sponsored-heading first-heading">Sponsor Chamois &#129351;</h3>
+              </div>
+            </div>
+            {{ end }}
+            <div class="sponsors-area">
+                {{ range $i, $sponsor := $.Site.Data.sponsors.chamois }}
+                  {{ if modBool $i 3 }}
+                  <div class="row">
+                  {{end}}
+                      <div class="single">
+                        <a href="{{ $sponsor.url_en }}" target="_blank"
+                            data-placement="top" data-toggle="tooltip" data-html="true"
+                            data-original-title="{{ $sponsor.description_en }}">
+                          <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                      </div>
+                  {{ if modBool (add $i 1) 3 }}
+                  </div>
+                  {{end}}                  
+                {{ end }}
+            </div>
+            {{ if isset .Site.Data.sponsors "etoile" }}
+            <div class="row">
+                <div class="col-xs-12">
+                  <h3 class="sponsored-heading">Sponsors Étoile &#9734;</h3>
+                </div>
+            </div>
+            {{ end }}
+            <div class="sponsors-area">
+                {{ range $i, $sponsor := $.Site.Data.sponsors.etoile }}
+                  {{ if modBool $i 3 }}
+                  <div class="row">
+                  {{end}}
+                      <div class="single">
+                        <a href="{{ $sponsor.url_en }}" target="_blank"
+                            data-placement="top" data-toggle="tooltip" data-html="true"
+                            data-original-title="{{ $sponsor.description_en }}">
+                          <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                      </div>
+                  {{ if modBool (add $i 1) 3 }}
+                  </div>
+                  {{end}}                  
+                {{ end }}
+            </div>
+            {{ if isset .Site.Data.sponsors "flocon" }}
+            <div class="row">
+              <div class="col-xs-12">
+                <h3 class="sponsored-heading">Sponsors Flocon ❄</h3>
+              </div>
+            </div>
+            {{ end }}
+            <div class="sponsors-area">
+                {{ range $i, $sponsor := $.Site.Data.sponsors.flocon }}
+                  {{ if modBool $i 3 }}
+                  <div class="row">
+                  {{end}}
+                      <div class="single">
+                        <a href="{{ $sponsor.url_en }}" target="_blank"
+                            data-placement="top" data-toggle="tooltip" data-html="true"
+                            data-original-title="{{ $sponsor.description_en }}">
+                          <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                      </div>
+                  {{ if modBool (add $i 1) 3 }}
+                  </div>
+                  {{end}}                  
+                {{ end }}
+            </div>
+
+            <div class="row">
+              <div class="col-xs-12 text-center">
+                <div class="snc-heading-area">
+                  <h2 class="sponsored-heading-previous">Sponsors 2019</h2>
+                  <p class="text">
+                  Without them SnowCamp 2019 would have not been possible.
+                  A big Thank You to our sponsors 2019!
+                  </p>
+                </div>
+                </div>
+              </div>        
+            
+            <div class="sponsors-area">
+              <div class="row">
+                <div class="single">
+                  <a href="https://www.thalesgroup.com/en" target="_blank"
+                     data-placement="top" data-toggle="tooltip" data-html="true"
+                     data-original-title="">
+                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/thales.png" alt="Thales"/></a>
+                </div>
+              </div>
+                <div class="row">
+                  <div class="single">
+                    <a href="https://www.zenika.com/" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="<strong>Zenika</strong>, technological and organizational innovation. Building together a simpler, more open, freer and accessible world. &lt;coding the world&gt;">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2018/zenika.png" alt="Zenika"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="http://www.norsys.fr/" target="_blank"
+                       data-placement="top" data-toggle="tooltip" data-html="true"
+                       data-original-title="Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2018/norsys.png" alt="Norsys"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="https://www.forgerock.com/" target="_blank"
+                       data-placement="top" data-toggle="tooltip" data-html="true"
+                       data-original-title="<strong>ForgeRock®</strong> is the Digital Identity Management company transforming the way organizations interact securely with customers, employees, devices, and things. Organizations adopt the ForgeRock Identity Platform™ as their digital identity system of record to monetize customer relationships, address stringent regulations for privacy and consent (GDPR, HIPAA, FCC privacy, etc.), and leverage the internet of things. ForgeRock serves hundreds of brands, including Morningstar, Vodafone, GEICO, Toyota and Pearson, as well as governments such as Norway, New Zealand, and Belgium, among many others. Headquartered in San Francisco, California, ForgeRock has offices in Austin, London, Bristol, Grenoble, Munich, Paris, Oslo, Singapore, Sydney and Vancouver, Washington.">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2018/forgerock.png" alt="ForgeRock"/></a>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="single">
+                    <a href="http://www.open-groupe.com/" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="General IT services company (Java, C#, ReactJS, Angular,…), specialized on digital expertises (IoT, Big Data, Market Place, Mobility &amp; Geolocalisation, Digital Communication), with a strong focus on employees relationship and customer proximity">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2019/open.png" alt="Open"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="http://www.stack-labs.com" target="_blank"
+                      data-placement="top" data-toggle="tooltip" data-html="true"
+                      data-original-title="The new generation tech company. Big Data pure player, turning data into valuable services.">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2019/stacklabs.png" alt="StackLabs"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="https://www.criteo.com/" target="_blank"
+                      data-placement="top" data-toggle="tooltip" data-html="true"
+                      data-original-title="Criteo (CRTO), the leader in commerce marketing, is building the highest performing and open commerce marketing ecosystem to drive profits and sales for retailers and brands. 2,700 Criteo team members partner with 16,000 customers and thousands of publishers across the globe to deliver performance at scale by connecting shoppers to the things they need and love. Designed for commerce, Criteo Commerce Marketing Ecosystem sees over $550 billion in annual commerce sales data.">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2019/crite.png" alt="Criteo" /></a>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="single">
+                    <a href="https://kaizen-solutions.net/" target="_blank"
+                       data-placement="top" data-toggle="tooltip" data-html="true"
+                       data-original-title="Notre société de services accompagne de grands groupes industriels sur Grenoble et sur Lyon en apportant des solutions logicielles haut de gamme sur l’ensemble des couches logicielles du capteur jusqu’au cloud. Partenaire boîte blanche, nous accompagnons nos clients sur leurs systèmes d’informations connectés temps réel à travers des solutions qui répondent à des projets complexes, portant sur de forts enjeux économiques, techniques et humains.
+                                            <br/>Vous avez envie de rejoindre une jeune société à taille humaine ? Qui se préoccupe de vous proposer des projets qui correspondent à vos attentes ?
+                                            <br/>Être vrai avant d’être différent, voilà notre vision du métier du service !">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2018/kaizen.png" alt="Kaizen Solutions"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="https://www.soprasteria.com/en/home" target="_blank"
+                       data-placement="top" data-toggle="tooltip" data-html="true"
+                       data-original-title="">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2018/sopra-steria.png" alt="Sopra Steria"/></a>
+                  </div>
+                  <div class="single">
+                    <a href="https://www.kelkoogroup.com/" target="_blank"
+                       data-placement="top" data-toggle="tooltip" data-html="true"
+                       data-original-title="Kelkoo Group is an ecommerce marketing platform that connects our merchants’ products to a network of proprietary shopping websites and premium publishers. Our 20 years of experience in ecommerce, digital marketing and consumer analytics, provide efficient solutions in 22 countries worldwide.">
+                      <img src="{{.Site.BaseURL}}/img/sponsors/2019/kelkoogroup.png" alt="Kelkoo"/></a>
+                  </div>
+                </div>
+              <div class="row">
+                <div class="single">
+                  <a href="https://www.salesforce.com/" target="_blank"
+                    data-placement="top" data-toggle="tooltip" data-html="true"
+                    data-original-title="Salesforce is the world’s #1 Customer Relationship Management (CRM) platform. Our cloud-based applications for sales, service, marketing, and more don’t require IT experts to set up or manage — simply log in and start connecting to customers in a whole new way. The expertise of the Grenoble R&D centre covers a wide range of areas from information retrieval, query understanding, machine learning, artificial intelligence, distributed computing, large scale distributed processing, from user interface to backend infrastructure. The centre is looking for talented and motivated individuals to join and to contribute to the future of Search at Salesforce.">
+                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/salesforce.png" alt="Salesforce"/></a>
+                </div>
+                <div class="single">
+                  <a href="https://www.orange.com/" target="_blank"
+            data-placement="top" data-toggle="tooltip" data-html="true"
+                    data-original-title="Orange Group has a strong expertise in its historical telecoms business and is also becoming so in the software part. For several years, Orange has been investing in the internal development of its strategic products and services to offer our customers the best possible experience and innovate. Orange operates in France and in many countries in Europe, Africa and the Middle East.">
+                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/orange.png" alt="Orange"/></a>
+                </div>
+                <div class="single">
+                  <a href="https://www.bonitasoft.com/" target="_blank">
+                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/bonitasoft.png" alt="BonitSoft"/></a>
+                </div>
+              </div>
+              <div class="row">
+                <div class="single">
+                  <a href="https://www.exoscale.com/" target="_blank">
+                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/exoscale.png" alt="Exoscale"/></a>
+                </div>
+              </div>
+            </div>
+
             <div class="sponsors-btn-area">
               <a class="snc-btn snc-btn-big" href="{{.Site.BaseURL}}{{ .Lang }}/sponsors"><span>Become a sponsor</span></a>
             </div>
-          </div>
 
-          <div class="row">
-            <div class="col-xs-12 text-center">
-              <div class="snc-heading-area">
-                <h2 class="sponsored-heading-previous">Sponsors 2019</h2>
-                <p class="text">
-                Without them SnowCamp 2019 would have not been possible.
-                A big Thank You to our sponsors 2019!
-                </p>
-              </div>
-              </div>
-            </div>        
-          
-          <div class="sponsors-area">
             <div class="row">
-              <div class="single">
-                <a href="https://www.thalesgroup.com/en" target="_blank"
-                   data-placement="top" data-toggle="tooltip" data-html="true"
-                   data-original-title="">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/thales.png" alt="Thales"/></a>
+              <div class="col-xs-12">
+                <h3 class="sponsored-heading">Partners</h3>
               </div>
             </div>
-              <div class="row">
-                <div class="single">
-                  <a href="https://www.zenika.com/" target="_blank"
-                      data-placement="top" data-toggle="tooltip" data-html="true"
-                      data-original-title="<strong>Zenika</strong>, technological and organizational innovation. Building together a simpler, more open, freer and accessible world. &lt;coding the world&gt;">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/zenika.png" alt="Zenika"/></a>
-                </div>
-                <div class="single">
-                  <a href="http://www.norsys.fr/" target="_blank"
-                     data-placement="top" data-toggle="tooltip" data-html="true"
-                     data-original-title="Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/norsys.png" alt="Norsys"/></a>
-                </div>
-                <div class="single">
-                  <a href="https://www.forgerock.com/" target="_blank"
-                     data-placement="top" data-toggle="tooltip" data-html="true"
-                     data-original-title="<strong>ForgeRock®</strong> is the Digital Identity Management company transforming the way organizations interact securely with customers, employees, devices, and things. Organizations adopt the ForgeRock Identity Platform™ as their digital identity system of record to monetize customer relationships, address stringent regulations for privacy and consent (GDPR, HIPAA, FCC privacy, etc.), and leverage the internet of things. ForgeRock serves hundreds of brands, including Morningstar, Vodafone, GEICO, Toyota and Pearson, as well as governments such as Norway, New Zealand, and Belgium, among many others. Headquartered in San Francisco, California, ForgeRock has offices in Austin, London, Bristol, Grenoble, Munich, Paris, Oslo, Singapore, Sydney and Vancouver, Washington.">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/forgerock.png" alt="ForgeRock"/></a>
-                </div>
-              </div>
-              <div class="row">
-                <div class="single">
-                  <a href="http://www.open-groupe.com/" target="_blank"
-                      data-placement="top" data-toggle="tooltip" data-html="true"
-                      data-original-title="General IT services company (Java, C#, ReactJS, Angular,…), specialized on digital expertises (IoT, Big Data, Market Place, Mobility &amp; Geolocalisation, Digital Communication), with a strong focus on employees relationship and customer proximity">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/open.png" alt="Open"/></a>
-                </div>
-                <div class="single">
-                  <a href="http://www.stack-labs.com" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="The new generation tech company. Big Data pure player, turning data into valuable services.">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/stacklabs.png" alt="StackLabs"/></a>
-                </div>
-                <div class="single">
-                  <a href="https://www.criteo.com/" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="Criteo (CRTO), the leader in commerce marketing, is building the highest performing and open commerce marketing ecosystem to drive profits and sales for retailers and brands. 2,700 Criteo team members partner with 16,000 customers and thousands of publishers across the globe to deliver performance at scale by connecting shoppers to the things they need and love. Designed for commerce, Criteo Commerce Marketing Ecosystem sees over $550 billion in annual commerce sales data.">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/crite.png" alt="Criteo" /></a>
-                </div>
-              </div>
-              <div class="row">
-                <div class="single">
-                  <a href="https://kaizen-solutions.net/" target="_blank"
-                     data-placement="top" data-toggle="tooltip" data-html="true"
-                     data-original-title="Notre société de services accompagne de grands groupes industriels sur Grenoble et sur Lyon en apportant des solutions logicielles haut de gamme sur l’ensemble des couches logicielles du capteur jusqu’au cloud. Partenaire boîte blanche, nous accompagnons nos clients sur leurs systèmes d’informations connectés temps réel à travers des solutions qui répondent à des projets complexes, portant sur de forts enjeux économiques, techniques et humains.
-                                          <br/>Vous avez envie de rejoindre une jeune société à taille humaine ? Qui se préoccupe de vous proposer des projets qui correspondent à vos attentes ?
-                                          <br/>Être vrai avant d’être différent, voilà notre vision du métier du service !">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/kaizen.png" alt="Kaizen Solutions"/></a>
-                </div>
-                <div class="single">
-                  <a href="https://www.soprasteria.com/en/home" target="_blank"
-                     data-placement="top" data-toggle="tooltip" data-html="true"
-                     data-original-title="">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2018/sopra-steria.png" alt="Sopra Steria"/></a>
-                </div>
-                <div class="single">
-                  <a href="https://www.kelkoogroup.com/" target="_blank"
-                     data-placement="top" data-toggle="tooltip" data-html="true"
-                     data-original-title="Kelkoo Group is an ecommerce marketing platform that connects our merchants’ products to a network of proprietary shopping websites and premium publishers. Our 20 years of experience in ecommerce, digital marketing and consumer analytics, provide efficient solutions in 22 countries worldwide.">
-                    <img src="{{.Site.BaseURL}}/img/sponsors/2019/kelkoogroup.png" alt="Kelkoo"/></a>
-                </div>
-              </div>
-            <div class="row">
-              <div class="single">
-                <a href="https://www.salesforce.com/" target="_blank"
-                  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Salesforce is the world’s #1 Customer Relationship Management (CRM) platform. Our cloud-based applications for sales, service, marketing, and more don’t require IT experts to set up or manage — simply log in and start connecting to customers in a whole new way. The expertise of the Grenoble R&D centre covers a wide range of areas from information retrieval, query understanding, machine learning, artificial intelligence, distributed computing, large scale distributed processing, from user interface to backend infrastructure. The centre is looking for talented and motivated individuals to join and to contribute to the future of Search at Salesforce.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/salesforce.png" alt="Salesforce"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.orange.com/" target="_blank"
-				  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Orange Group has a strong expertise in its historical telecoms business and is also becoming so in the software part. For several years, Orange has been investing in the internal development of its strategic products and services to offer our customers the best possible experience and innovate. Orange operates in France and in many countries in Europe, Africa and the Middle East.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/orange.png" alt="Orange"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.bonitasoft.com/" target="_blank">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/bonitasoft.png" alt="BonitSoft"/></a>
-              </div>
+            <div class="sponsors-area">
+                {{ range $i, $sponsor := $.Site.Data.sponsors.partners }}
+                  {{ if modBool $i 3 }}
+                  <div class="row">
+                  {{end}}
+                      <div class="single">
+                        <a href="{{ $sponsor.url_en }}" target="_blank"
+                            data-placement="top" data-toggle="tooltip" data-html="true"
+                            data-original-title="{{ $sponsor.description_en }}">
+                          <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                      </div>
+                  {{ if modBool (add $i 1) 3 }}
+                  </div>
+                  {{end}}                  
+                {{ end }}
             </div>
-            <div class="row">
-              <div class="single">
-                <a href="https://www.exoscale.com/" target="_blank">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/exoscale.png" alt="Exoscale"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-xs-12">
-              <h3 class="sponsored-heading">Partners</h3>
-            </div>
-          </div>
-          <div class="sponsors-area">
-            <div class="row">
-              <div class="single">
-                <a href="https://www.manning.com/" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="Manning is an independent publisher of computer books for software developers, engineers, architects, system administrators, managers and all who are professionally involved with the computer business. The books we publish cover a huge range of topics that the modern developer needs; from languages and frameworks, to best practices for team leaders.">
-                  <img src="{{.Site.BaseURL}}/img/partners/2019/manning.png" alt="Manning"/></a>
-              </div>
-              <div class="single">
-                <a href="http://alpesjug.fr/" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="AlpesJug is the Java User Group of the Grenoble area, and the initiator of the Snowcamp conference.">
-                  <img src="{{.Site.BaseURL}}/img/partners/alpesjug.png" alt="AlpesJug"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.stickermule.com/uk" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="Sticker Mule is the fastest and easiest way to buy custom printed products. Thousands of people in the EU trust us to make kick-ass stickers, labels, magnets, badges & more. Order in seconds and get free online proofs, free shipping, and super fast turnaround.">
-                  <img src="{{.Site.BaseURL}}/img/partners/2019/stickermule.png" alt="Sticker Mule"/></a>
-              </div>
-            </div>
-          </div>
-        </div> <!-- Container -->
-      </div><!-- Inner -->
-    </div> <!-- Inner-bg -->
-  </div> <!-- Sponsors -->
-</section>
-
+          </div> <!-- Container -->
+        </div><!-- Inner -->
+      </div> <!-- Inner-bg -->
+    </div> <!-- Sponsors -->
+  </section>
 <section>
   <div id="venue" class="snc-venue">
     <div class="snc-inner">

--- a/layouts/partials/index.fr.html
+++ b/layouts/partials/index.fr.html
@@ -1,195 +1,22 @@
 <section>
-  <div class="snc-banner">
-    <div class="snc-banner-style">
-      <div class="snc-inner">
-        <div class="container">
-          <div class="row">
-            <div class="col-xs-12">
-              <div class="banner-info">
-                <div class="snc-countdown-area">
-                  <div id="snc-countdown" data-date="2020/1/22">
-                    <span class="snc-days">100 <i> Jours </i></span>
-                    <span class="snc-hr">14 <i> Heures </i></span>
-                    <span class="snc-min">15 <i> Minutes </i></span>
-                    <span class="snc-sec">29<i> Secondes </i></span>
+    <div class="snc-banner">
+      <div class="snc-banner-style">
+        <div class="snc-inner">
+          <div class="container">
+            <div class="row">
+              <div class="col-xs-12">
+                <div class="banner-info">
+                  <div class="snc-countdown-area">
+                    <div id="snc-countdown" data-date="2020/1/22">
+                      <span class="snc-days">100 <i> Jours </i></span>
+                      <span class="snc-hr">14 <i> Heures </i></span>
+                      <span class="snc-min">15 <i> Minutes </i></span>
+                      <span class="snc-sec">29<i> Secondes </i></span>
+                    </div>
                   </div>
+                  <h2 class="title">Snowcamp <span>2020</span></h2>
+                  <h3 class="date"><span>22-25 Janvier </span>2020, Grenoble</h3>
                 </div>
-                <h2 class="title">Snowcamp <span>2020</span></h2>
-                <h3 class="date"><span>22-25 Janvier </span>2020, Grenoble</h3>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div id="snc-snowcamp" class="snc-snowcamp">
-    <div class="snc-inner">
-      <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="snc-heading-area">
-              <h2 class="snc-heading">
-                <span class="back-heading">
-                    <i class="fa fa-snowflake-o" aria-hidden="true"></i>
-                </span>
-                <span class="heading">Snowcamp</span>
-              </h2>
-
-              <p class="text">
-                Une conférence unique pour les devs, les ops et les archis
-              </p>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-univ.png" alt="universities" width="30%">
-              <h3 class="title">Universités</h3>
-              <p class="info">Une journée de formation en profondeur<br/>(2 formations de 3 heures au choix).</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-conf.png" alt="conference" width="30%">
-              <h3 class="title">Conférences</h3>
-              <p class="info">2 jours de conférences avec des présentations de 45 minutes.</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-unconference.png" alt="unconference" width="30%">
-              <h3 class="title">Unconference</h3>
-              <p class="info">Une journée d'échange sur les pistes mêlant orateurs et participants.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div id="snc-innovation" class="snc-innovation">
-    <div class="snc-inner">
-      <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="snc-heading-area">
-              <h2 class="snc-heading">
-                <span class="back-heading">
-                    <i class="fa fa-cogs" aria-hidden="true"></i>
-                </span>
-                <span class="heading">Innovation &amp; Recherche</span>
-              </h2>
-
-              <p class="text">
-                Une conférence à haut niveau technique réunissant des ingénieurs et des académiques
-              </p>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-dev.png" alt="dev" width="30%">
-              <h3 class="title">Innovation</h3>
-              <p class="info">Découvrez les outils, frameworks et technologies d'aujourd'hui et de demain.</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-cloud.png" alt="conference" width="30%">
-              <h3 class="title">Échange</h3>
-              <p class="info">Rencontrez et échangez avec d'autres devs, ops, archis et orateurs.</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-4">
-            <div class="single">
-              <img src="{{.Site.BaseURL}}/img/icon-academic.png" alt="unconference" width="30%">
-              <h3 class="title">Recherche</h3>
-              <p class="info">Découvrez les travaux des chercheurs sur les tendances et sujets du moment.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div id="program" class="snc-programme">
-    <div class="snc-inner">
-      <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="snc-heading-area">
-              <h2 class="snc-heading">
-                <span class="back-heading">
-                    <i class="fa fa-calendar" aria-hidden="true"></i>
-                </span>
-                <span class="heading">{{ i18n "cfp_program_translation" }}</span>
-              </h2>
-
-              <div class="ui steps">
-                  <div class="active step">
-                    <i class="inbox icon"></i>
-                    <div class="content">
-                      <div class="title">Ouverture du CFP</div>
-                      <div class="description">Été 2019</div>
-                    </div>
-                  </div>
-                  <div class="active step">
-                    <i class="spinner icon"></i>
-                    <div class="content">
-                      <div class="title">Fermeture du CFP</div>
-                      <div class="description">Mi-Octobre 2019</div>
-                    </div>
-                  </div>
-                  <div class="active step">
-                    <i class="mail icon"></i>
-                    <div class="content">
-                      <div class="title">Notifications</div>
-                      <div class="description">Début Novembre 2019</div>
-                    </div>
-                  </div>
-                  <div class="active step">
-                    <i class="checked calendar icon"></i>
-                    <div class="content">
-                      <div class="title">Snowcamp</div>
-                      <div class="description">22-25 Janvier 2020</div>
-                    </div>
-                  </div>
-                </div> 
-              </div>
-            </div>
-          </div>
-          <div class="row">
-             <div class="col-xs-12 col-sm-6 col-md-6">
-              <div class="single">
-                <img src="{{.Site.BaseURL}}/img/themas.png" alt="themas">
-              </div>
-            </div> 
-            <div class="col-xs-12 col-sm-6 col-md-6">
-              <div class="single">
-                <p>Le CFP n'est pas encore ouvert... Soyez patients ! Suivez-nous sur Twitter <a class="sp-tw" href="https://twitter.com/SnowCampIO"><i class="fa fa-twitter"></i></a> pour être notifiés de
-                  l'ouverture du CFP.</p>
-                <br/>
-                <p>Quelques conseils :</p>
-                <ul>
-                  <li>Choisissez bien votre titre</li>
-                  <li>Expliquez ce que les participants vont voir et apprendre</li>
-                  <li>Faites des démos</li>
-                  <li>Soumettez tôt !</li>
-                </ul>
-                <br/>
-                <p>Les sessions peuvent être proposées en français ou en anglais. Les présentations sont sélectionnées
-                  par un comité neutre et ouvert. Alors lancez-vous !
-                </p>
               </div>
             </div>
           </div>
@@ -197,245 +24,486 @@
       </div>
     </div>
   </section>
-
-<section>
-  <div id="sponsors" class="snc-sponsors">
-    <div class="snc-inner-bg">
+  
+  <section>
+    <div id="snc-snowcamp" class="snc-snowcamp">
       <div class="snc-inner">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12 text-center">
+            <div class="col-xs-12">
               <div class="snc-heading-area">
                 <h2 class="snc-heading">
-                  <span class="back-heading"><i class="fa fa-thumbs-up" aria-hidden="true"></i></span>
-                  <span class="heading">Sponsors 2020</span>
+                  <span class="back-heading">
+                      <i class="fa fa-snowflake-o" aria-hidden="true"></i>
+                  </span>
+                  <span class="heading">Snowcamp</span>
                 </h2>
+  
                 <p class="text">
-                  Pour réussir l'édition 2020, nous avons besoin de vous!
+                  Une conférence unique pour les devs, les ops et les archis
                 </p>
               </div>
             </div>
-            <div class="sponsors-btn-area">
-              <a class="snc-btn snc-btn-big" href="{{.Site.BaseURL}}{{ .Lang }}/sponsors"><span>Devenir sponsor</span></a>
-            </div>
           </div>
           <div class="row">
-            <div class="col-xs-12 text-center">
-                <div class="snc-heading-area">
-                  <h2 class="sponsored-heading-previous">Sponsors 2019</h2>
-                  <p class="text">
-                      Sans eux, l'aventure 2019 n'aurait pas été possible.
-                      Un grand merci à nos sponsors 2019 !
-                  </p>
-                </div>
-            </div>
-          </div>  
-          <div class="sponsors-area">
-            <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-4">
               <div class="single">
-                <a href="https://www.thalesgroup.com/fr" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/thales.png" alt="Thales"/></a>
+                <img src="{{.Site.BaseURL}}/img/icon-univ.png" alt="universities" width="30%">
+                <h3 class="title">Universités</h3>
+                <p class="info">Une journée de formation en profondeur<br/>(2 formations de 3 heures au choix).</p>
               </div>
             </div>
-            <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-4">
               <div class="single">
-                <a href="https://www.zenika.com/" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="<strong>Zenika</strong>, L’innovation technologique, organisationnelle et managériale permettant de construire ensemble un monde plus simple, plus ouvert, plus libre et plus accessible à tous. &lt;coding the world&gt;">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/zenika.png" alt="Zenika"/></a>
-              </div>
-              <div class="single">
-                <a href="http://www.norsys.fr/" target="_blank"
-                  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/norsys.png" alt="Norsys"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.forgerock.fr/" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="<strong>ForgeRock®</strong>, le leader sur le marché de la gestion de l’identité numérique, transforme la manière dont les entreprises établissent des échanges sécurisés entre les personnes, les services et les objets. Les entreprises adoptent la ForgeRock Identity Platform™ en tant que système d’identité numérique pour rentabiliser les échanges avec leurs clients, respecter les règlements sur la confidentialité et le consentement (GDPR, HIPAA, PSD2, Open Banking, etc.), et tirer le meilleur profit de l’Internet des objets. ForgeRock est le fournisseur de centaines de marques comme Morningstar, Vodafone, GEICO, Toyota ou Pearson et de nombreux gouvernements comme la Norvège, le Canada ou la Belgique, et gère des milliards d’identités dans le monde entier. ForgeRock dispose de bureaux dans toute l’Europe, aux États-Unis et en Asie.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/forgerock.png" alt="ForgeRock"/></a>
+                <img src="{{.Site.BaseURL}}/img/icon-conf.png" alt="conference" width="30%">
+                <h3 class="title">Conférences</h3>
+                <p class="info">2 jours de conférences avec des présentations de 45 minutes.</p>
               </div>
             </div>
-            <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-4">
               <div class="single">
-                <a href="http://www.open-groupe.com/" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="ESN généraliste et multi technologique (Java, C#, ReactJS, Angular,…) , résolument tournée vers l’expertise digitale (IoT, Big Data, E-commerce, mobilité, innovation), mettant un accent fort sur la relation collaborateur ainsi que sur la proximité clients">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/open.png" alt="Open"/></a>
-              </div>
-              <div class="single">
-                <a href="http://www.stack-labs.com" target="_blank"
-                  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="The new generation tech company. Big Data pure player, turning data into valuable services.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/stacklabs.png" alt="StackLabs"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.criteo.com/" target="_blank"
-                  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Criteo (CRTO), the leader in commerce marketing, is building the highest performing and open commerce marketing ecosystem to drive profits and sales for retailers and brands. 2,700 Criteo team members partner with 16,000 customers and thousands of publishers across the globe to deliver performance at scale by connecting shoppers to the things they need and love. Designed for commerce, Criteo Commerce Marketing Ecosystem sees over $550 billion in annual commerce sales data.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/crite.png" alt="Criteo" /></a>
-              </div>
-            </div>
-            <div class="row">
-              <div class="single">
-                <a href="https://kaizen-solutions.net/" target="_blank"
-                   data-placement="top" data-toggle="tooltip" data-html="true"
-                   data-original-title="Notre société de services accompagne de grands groupes industriels sur Grenoble et sur Lyon en apportant des solutions logicielles haut de gamme sur l’ensemble des couches logicielles du capteur jusqu’au cloud. Partenaire boîte blanche, nous accompagnons nos clients sur leurs systèmes d’informations connectés temps réel à travers des solutions qui répondent à des projets complexes, portant sur de forts enjeux économiques, techniques et humains.
-                                        <br/>Vous avez envie de rejoindre une jeune société à taille humaine ? Qui se préoccupe de vous proposer des projets qui correspondent à vos attentes ?
-                                        <br/>Être vrai avant d’être différent, voilà notre vision du métier du service !">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/kaizen.png" alt="Kaizen Solutions"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.soprasteria.com/fr/home" target="_blank"
-                    data-placement="top" data-toggle="tooltip" data-html="true"
-                    data-original-title="">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/sopra-steria.png" alt="Sopra Steria"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.kelkoogroup.com/fr/" target="_blank"
-                   data-placement="top" data-toggle="tooltip" data-html="true"
-                   data-original-title="Kelkoo Group est une plateforme marketing pour le e-commerce qui connecte les produits de nos marchands à nos sites propriétaires de comparaison de prix et à notre réseau premium de sites Publishers. Avec 20 ans d’expérience en e-commerce, marketing digital et analyse consommateur, nous proposons des solutions efficaces dans 22 pays à travers le monde">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/kelkoogroup.png" alt="Kelkoo"/></a>
-              </div>
-            </div>
-            <div class="row">
-              <div class="single">
-                <a href="https://www.salesforce.com/" target="_blank"
-                  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Salesforce est la plateforme n° 1 au monde des solutions de gestion de la relation client (CRM). Pour configurer ou gérer nos applications basées sur le cloud (pour les ventes, les services, le marketing et bien plus encore), inutile de recourir à des spécialistes en informatique. Connectez-vous et découvrez simplement cette nouvelle manière d'être en contact avec vos clients. Salesforce à Grenoble, c'est une équipe de développement logiciel avec une expertise unique en recherche d'information, machine learning et haute performance en environnement distribué multi-tenants (cloud). Nous sommes à la recherche de développeurs motivés et talentueux, de toute experience désireux de contribuer au futur du search à Salesforce.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2018/salesforce.png" alt="Salesforce"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.orange.fr/" target="_blank"
-				  data-placement="top" data-toggle="tooltip" data-html="true"
-                  data-original-title="Le Groupe Orange a une forte expertise sur son métier historique des télécoms et le devient aussi sur la partie software. Depuis plusieurs années, Orange investit dans le développement interne de ses produits et services stratégiques pour offrir à nos clients une expérience optimale et innover. Orange est présent en France et dans de nombreux pays en Europe, en Afrique et au Moyen Orient.">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/orange.png" alt="Orange"/></a>
-              </div>
-              <div class="single">
-                <a href="https://fr.bonitasoft.com/" target="_blank">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/bonitasoft.png" alt="BonitSoft"/></a>
-              </div>
-            </div>
-            <div class="row">
-              <div class="single">
-                <a href="https://www.exoscale.com" target="_blank">
-                  <img src="{{.Site.BaseURL}}/img/sponsors/2019/exoscale.png" alt="Exoscale"/></a>
+                <img src="{{.Site.BaseURL}}/img/icon-unconference.png" alt="unconference" width="30%">
+                <h3 class="title">Unconference</h3>
+                <p class="info">Une journée d'échange sur les pistes mêlant orateurs et participants.</p>
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  
+  <section>
+    <div id="snc-innovation" class="snc-innovation">
+      <div class="snc-inner">
+        <div class="container">
           <div class="row">
             <div class="col-xs-12">
-              <h3 class="sponsored-heading">Partenaires</h3>
+              <div class="snc-heading-area">
+                <h2 class="snc-heading">
+                  <span class="back-heading">
+                      <i class="fa fa-cogs" aria-hidden="true"></i>
+                  </span>
+                  <span class="heading">Innovation &amp; Recherche</span>
+                </h2>
+  
+                <p class="text">
+                  Une conférence à haut niveau technique réunissant des ingénieurs et des académiques
+                </p>
+              </div>
             </div>
           </div>
-          <div class="sponsors-area">
+          <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-4">
+              <div class="single">
+                <img src="{{.Site.BaseURL}}/img/icon-dev.png" alt="dev" width="30%">
+                <h3 class="title">Innovation</h3>
+                <p class="info">Découvrez les outils, frameworks et technologies d'aujourd'hui et de demain.</p>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-6 col-md-4">
+              <div class="single">
+                <img src="{{.Site.BaseURL}}/img/icon-cloud.png" alt="conference" width="30%">
+                <h3 class="title">Échange</h3>
+                <p class="info">Rencontrez et échangez avec d'autres devs, ops, archis et orateurs.</p>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-6 col-md-4">
+              <div class="single">
+                <img src="{{.Site.BaseURL}}/img/icon-academic.png" alt="unconference" width="30%">
+                <h3 class="title">Recherche</h3>
+                <p class="info">Découvrez les travaux des chercheurs sur les tendances et sujets du moment.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  
+  <section>
+    <div id="program" class="snc-programme">
+      <div class="snc-inner">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12">
+              <div class="snc-heading-area">
+                <h2 class="snc-heading">
+                  <span class="back-heading">
+                      <i class="fa fa-calendar" aria-hidden="true"></i>
+                  </span>
+                  <span class="heading">{{ i18n "cfp_program_translation" }}</span>
+                </h2>
+  
+                <div class="ui steps">
+                    <div class="active step">
+                      <i class="inbox icon"></i>
+                      <div class="content">
+                        <div class="title">Ouverture du CFP</div>
+                        <div class="description">Été 2019</div>
+                      </div>
+                    </div>
+                    <div class="active step">
+                      <i class="spinner icon"></i>
+                      <div class="content">
+                        <div class="title">Fermeture du CFP</div>
+                        <div class="description">Mi-Octobre 2019</div>
+                      </div>
+                    </div>
+                    <div class="active step">
+                      <i class="mail icon"></i>
+                      <div class="content">
+                        <div class="title">Notifications</div>
+                        <div class="description">Début Novembre 2019</div>
+                      </div>
+                    </div>
+                    <div class="active step">
+                      <i class="checked calendar icon"></i>
+                      <div class="content">
+                        <div class="title">Snowcamp</div>
+                        <div class="description">22-25 Janvier 2020</div>
+                      </div>
+                    </div>
+                  </div> 
+                </div>
+              </div>
+            </div>
             <div class="row">
-              <div class="single">
-                <a href="https://www.manning.com/" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="Manning est un éditeur indépendant de livres d'informatique pour les développeurs logiciel, ingénieurs, architectes, administrateurs système, managers et tous les professionnels de l'informatique. Les livres que nous publions couvrent un large éventail de sujets nécessaires au développeur moderne; des langages et frameworks, aux bonnes practiques pour les responsables d'équipes.">
-                  <img src="{{.Site.BaseURL}}/img/partners/2019/manning.png" alt="Manning"/></a>
-              </div>
-              <div class="single">
-                <a href="http://alpesjug.fr/" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="AlpesJug est le groupe des utilisateurs Java de la région grenobloise, et à l'origine du Snowcamp.">
-                  <img src="{{.Site.BaseURL}}/img/partners/alpesjug.png" alt="AlpesJug"/></a>
-              </div>
-              <div class="single">
-                <a href="https://www.stickermule.com/fr" target="_blank"
-                data-placement="top" data-toggle="tooltip" data-html="true"
-                data-original-title="Avec Sticker Mule, achetez rapidement et facilement des produits imprimés personnalisés. Il suffit de 60 secondes pour passer votre commande. Il nous faudra ensuite quelques jours pour transformer vos modèles et images en stickers, magnets, badges, étiquettes autocollantes ou emballages personnalisés. Nous offrons des épreuves en ligne gratuites, un délai de production extrêmement court et la livraison à l'international est gratuite.">
-                  <img src="{{.Site.BaseURL}}/img/partners/2019/stickermule.png" alt="Sticker Mule"/></a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div id="venue" class="snc-venue">
-    <div class="snc-inner">
-      <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="snc-heading-area">
-              <h2 class="snc-heading">
-                <span class="back-heading">
-                    <i class="fa fa-map-o" aria-hidden="true"></i>
-                </span>
-                <span class="heading">Venir</span>
-              </h2>
-              <p class="text">
-                SnowCamp se déroulera au Centre de Congrès du WTC (World Trade Center) de Grenoble à la fois pour les Universités et les Conférences.
-              </p>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6 col-md-6 polaroid-images">
-            <div class="single">
-              <a href="http://www.congres-wtcgrenoble.com/fr/annuaire-geolocalise?field_service_tid%5B%5D=73&field_service_tid%5B%5D=69&field_service_tid%5B%5D=68&field_service_tid%5B%5D=70" target="_blank" class="rot-4" title="WTC Grenoble">
-                <img src="{{.Site.BaseURL}}/img/wtc.jpg" alt="WTC Grenoble" width="40%">
-              </a>
-            </div>
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-6">
-            <div class="single">
-              <p>Les Universités et les Conférences auront toutes lieux à la
-                <a href="http://www.congres-wtcgrenoble.com/fr" target="_blank"><strong>"WTC World Trade Center Grenoble"</strong></a>,
-                 un Centre de Conférences au cœur de Grenoble.</p>
-              <br/>
-              <p><strong>5 - 7 , place Robert Schuman<br/>38025 Grenoble</strong></p>
-              <br/>
-              <p>Vous pouvez y accéder :</p>
-              <ul>
-                <li>par la ligne B du Tram (direction Grenoble Presqu'île), arrêt "Palais De Justice - Gare"</li>
-                <li>en voiture (vous pouvez vous garer aux parkings Doyen Weil ou d'Europole Gare)
+               <div class="col-xs-12 col-sm-6 col-md-6">
+                <div class="single">
+                  <img src="{{.Site.BaseURL}}/img/themas.png" alt="themas">
+                </div>
+              </div> 
+              <div class="col-xs-12 col-sm-6 col-md-6">
+                <div class="single">
+                  <p>Le CFP n'est pas encore ouvert... Soyez patients ! Suivez-nous sur Twitter <a class="sp-tw" href="https://twitter.com/SnowCampIO"><i class="fa fa-twitter"></i></a> pour être notifiés de
+                    l'ouverture du CFP.</p>
+                  <br/>
+                  <p>Quelques conseils :</p>
                   <ul>
-                    <li>en arrivant de Lyon ou de Valence, prenez la sortie d’autoroute "Europole - Gares" et suivre la direction Europole</li>
-                    <li>en arrivant de Chambéry, Gap ou Sisteron, prenez la rocade sud, suivre la direction Lyon par l’autoroute, puis la
-                      sortie "Europole - Gares" et suivre la direction Europole</li>
+                    <li>Choisissez bien votre titre</li>
+                    <li>Expliquez ce que les participants vont voir et apprendre</li>
+                    <li>Faites des démos</li>
+                    <li>Soumettez tôt !</li>
                   </ul>
-                </li>
-                <li>en train ou bus : utilisez le passage souterrain depuis la gare vers Europole</li>
-                <li>par avion : il y a des navettes d'aéroports : depuis Lyon Saint-Exupéry (17 rotations
-                  7j/7) et depuis Genève Cointrin (3 rotations, 7j/7)</li>
-                <li>en <a href="http://www.metromobilite.fr/velo.html" target="_blank">vélo</a></li>
-              </ul>
+                  <br/>
+                  <p>Les sessions peuvent être proposées en français ou en anglais. Les présentations sont sélectionnées
+                    par un comité neutre et ouvert. Alors lancez-vous !
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6 col-md-6">
-            <div class="single">
-              <p><strong>Latitude :</strong> 45.191113</p>
-              <p><strong>Longitude :</strong> 5.712145</p>
-            </div>
-            <div class="single">
-              <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2811.812207884478!2d5.711009615420941!3d45.190897559659334!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478af481b7661f97%3A0x2f475fe8d95f61e0!2sCentre+de+congr%C3%A8s+du+World+Trade+Center+Grenoble!5e0!3m2!1sfr!2sfr!4v1555137908940!5m2!1sfr!2sfr" width="500" height="400" frameborder="0" style="border:0" allowfullscreen></iframe>
-            </div>
-            <div class="single polaroid-images">
-              <a href="#" target="_blank" class="rot-4" title="WTC - Atrium (Crédit photo WTC)">
-                <img src="{{.Site.BaseURL}}/img/wtc-atrium.jpg" alt="WTC - Atrium (Crédit photo WTC)" width="40%">
-              </a>
+      </div>
+    </section>
+  
+    <section>
+        <div id="sponsors" class="snc-sponsors">
+          <div class="snc-inner-bg">
+            <div class="snc-inner">
+              <div class="container">
+                <div class="row">
+                  <div class="col-xs-12 text-center">
+                    <div class="snc-heading-area">
+                      <h2 class="snc-heading">
+                        <span class="back-heading"><i class="fa fa-thumbs-up" aria-hidden="true"></i></span>
+                        <span class="heading">Sponsors 2020</span>
+                      </h2>
+                      <p class="text">
+                          Ils nous ont déjà accordé leur confiance pour préparer ensemble l'édition 2020. <br/>
+                          Un grand merci à nos sponsors !
+                        </p>
+                    </div>
+                  </div>
+                </div>
+                {{ if isset .Site.Data.sponsors "chamois" }}
+                <div class="row">
+                  <div class="col-xs-12">
+                    <h3 class="sponsored-heading first-heading">Sponsor Chamois &#129351;</h3>
+                  </div>
+                </div>
+                {{ end }}
+                <div class="sponsors-area">
+                    {{ range $i, $sponsor := $.Site.Data.sponsors.chamois }}
+                      {{ if modBool $i 3 }}
+                      <div class="row">
+                      {{end}}
+                          <div class="single">
+                            <a href="{{ $sponsor.url_fr }}" target="_blank"
+                                data-placement="top" data-toggle="tooltip" data-html="true"
+                                data-original-title="{{ $sponsor.description_fr }}">
+                              <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                          </div>
+                      {{ if modBool (add $i 1) 3 }}
+                      </div>
+                      {{end}}                  
+                    {{ end }}
+                </div>
+                {{ if isset .Site.Data.sponsors "etoile" }}
+                <div class="row">
+                    <div class="col-xs-12">
+                      <h3 class="sponsored-heading">Sponsors Étoile &#9734;</h3>
+                    </div>
+                </div>
+                {{ end }}
+                <div class="sponsors-area">
+                    {{ range $i, $sponsor := $.Site.Data.sponsors.etoile }}
+                      {{ if modBool $i 3 }}
+                      <div class="row">
+                      {{end}}
+                          <div class="single">
+                            <a href="{{ $sponsor.url_fr }}" target="_blank"
+                                data-placement="top" data-toggle="tooltip" data-html="true"
+                                data-original-title="{{ $sponsor.description_fr }}">
+                              <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                          </div>
+                      {{ if modBool (add $i 1) 3 }}
+                      </div>
+                      {{end}}                  
+                    {{ end }}
+                </div>
+                {{ if isset .Site.Data.sponsors "flocon" }}
+                <div class="row">
+                  <div class="col-xs-12">
+                    <h3 class="sponsored-heading">Sponsors Flocon ❄</h3>
+                  </div>
+                </div>
+                {{ end }}
+                <div class="sponsors-area">
+                    {{ range $i, $sponsor := $.Site.Data.sponsors.flocon }}
+                      {{ if modBool $i 3 }}
+                      <div class="row">
+                      {{end}}
+                          <div class="single">
+                            <a href="{{ $sponsor.url_fr }}" target="_blank"
+                                data-placement="top" data-toggle="tooltip" data-html="true"
+                                data-original-title="{{ $sponsor.description_fr }}">
+                              <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                          </div>
+                      {{ if modBool (add $i 1) 3 }}
+                      </div>
+                      {{end}}                  
+                    {{ end }}
+                </div>
+
+                <div class="row">
+                  <div class="col-xs-12 text-center">
+                      <div class="snc-heading-area">
+                        <h2 class="sponsored-heading-previous">Sponsors 2019</h2>
+                        <p class="text">
+                            Sans eux, l'aventure 2019 n'aurait pas été possible.
+                            Un grand merci à nos sponsors 2019 !
+                        </p>
+                      </div>
+                  </div>
+                </div>  
+                <div class="sponsors-area">
+                  <div class="row">
+                    <div class="single">
+                      <a href="https://www.thalesgroup.com/fr" target="_blank"
+                          data-placement="top" data-toggle="tooltip" data-html="true"
+                          data-original-title="">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/thales.png" alt="Thales"/></a>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="single">
+                      <a href="https://www.zenika.com/" target="_blank"
+                          data-placement="top" data-toggle="tooltip" data-html="true"
+                          data-original-title="<strong>Zenika</strong>, L’innovation technologique, organisationnelle et managériale permettant de construire ensemble un monde plus simple, plus ouvert, plus libre et plus accessible à tous. &lt;coding the world&gt;">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/zenika.png" alt="Zenika"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="http://www.norsys.fr/" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="Norsys est une ESN spécialisée depuis plus de 20 ans dans le conseil en assistance à maîtrise d’ouvrage et l’ingénierie informatique sur les technologies Open source. Elle compte aujourd’hui 500 collaborateurs répartis sur Lille, Paris, Lyon, Grenoble, Nantes, Nice et Marrakech.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/norsys.png" alt="Norsys"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://www.forgerock.fr/" target="_blank"
+                          data-placement="top" data-toggle="tooltip" data-html="true"
+                          data-original-title="<strong>ForgeRock®</strong>, le leader sur le marché de la gestion de l’identité numérique, transforme la manière dont les entreprises établissent des échanges sécurisés entre les personnes, les services et les objets. Les entreprises adoptent la ForgeRock Identity Platform™ en tant que système d’identité numérique pour rentabiliser les échanges avec leurs clients, respecter les règlements sur la confidentialité et le consentement (GDPR, HIPAA, PSD2, Open Banking, etc.), et tirer le meilleur profit de l’Internet des objets. ForgeRock est le fournisseur de centaines de marques comme Morningstar, Vodafone, GEICO, Toyota ou Pearson et de nombreux gouvernements comme la Norvège, le Canada ou la Belgique, et gère des milliards d’identités dans le monde entier. ForgeRock dispose de bureaux dans toute l’Europe, aux États-Unis et en Asie.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/forgerock.png" alt="ForgeRock"/></a>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="single">
+                      <a href="http://www.open-groupe.com/" target="_blank"
+                          data-placement="top" data-toggle="tooltip" data-html="true"
+                          data-original-title="ESN généraliste et multi technologique (Java, C#, ReactJS, Angular,…) , résolument tournée vers l’expertise digitale (IoT, Big Data, E-commerce, mobilité, innovation), mettant un accent fort sur la relation collaborateur ainsi que sur la proximité clients">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/open.png" alt="Open"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="http://www.stack-labs.com" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="The new generation tech company. Big Data pure player, turning data into valuable services.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/stacklabs.png" alt="StackLabs"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://www.criteo.com/" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="Criteo (CRTO), the leader in commerce marketing, is building the highest performing and open commerce marketing ecosystem to drive profits and sales for retailers and brands. 2,700 Criteo team members partner with 16,000 customers and thousands of publishers across the globe to deliver performance at scale by connecting shoppers to the things they need and love. Designed for commerce, Criteo Commerce Marketing Ecosystem sees over $550 billion in annual commerce sales data.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/crite.png" alt="Criteo" /></a>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="single">
+                      <a href="https://kaizen-solutions.net/" target="_blank"
+                         data-placement="top" data-toggle="tooltip" data-html="true"
+                         data-original-title="Notre société de services accompagne de grands groupes industriels sur Grenoble et sur Lyon en apportant des solutions logicielles haut de gamme sur l’ensemble des couches logicielles du capteur jusqu’au cloud. Partenaire boîte blanche, nous accompagnons nos clients sur leurs systèmes d’informations connectés temps réel à travers des solutions qui répondent à des projets complexes, portant sur de forts enjeux économiques, techniques et humains.
+                                              <br/>Vous avez envie de rejoindre une jeune société à taille humaine ? Qui se préoccupe de vous proposer des projets qui correspondent à vos attentes ?
+                                              <br/>Être vrai avant d’être différent, voilà notre vision du métier du service !">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/kaizen.png" alt="Kaizen Solutions"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://www.soprasteria.com/fr/home" target="_blank"
+                          data-placement="top" data-toggle="tooltip" data-html="true"
+                          data-original-title="">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/sopra-steria.png" alt="Sopra Steria"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://www.kelkoogroup.com/fr/" target="_blank"
+                         data-placement="top" data-toggle="tooltip" data-html="true"
+                         data-original-title="Kelkoo Group est une plateforme marketing pour le e-commerce qui connecte les produits de nos marchands à nos sites propriétaires de comparaison de prix et à notre réseau premium de sites Publishers. Avec 20 ans d’expérience en e-commerce, marketing digital et analyse consommateur, nous proposons des solutions efficaces dans 22 pays à travers le monde">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/kelkoogroup.png" alt="Kelkoo"/></a>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="single">
+                      <a href="https://www.salesforce.com/" target="_blank"
+                        data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="Salesforce est la plateforme n° 1 au monde des solutions de gestion de la relation client (CRM). Pour configurer ou gérer nos applications basées sur le cloud (pour les ventes, les services, le marketing et bien plus encore), inutile de recourir à des spécialistes en informatique. Connectez-vous et découvrez simplement cette nouvelle manière d'être en contact avec vos clients. Salesforce à Grenoble, c'est une équipe de développement logiciel avec une expertise unique en recherche d'information, machine learning et haute performance en environnement distribué multi-tenants (cloud). Nous sommes à la recherche de développeurs motivés et talentueux, de toute experience désireux de contribuer au futur du search à Salesforce.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2018/salesforce.png" alt="Salesforce"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://www.orange.fr/" target="_blank"
+                data-placement="top" data-toggle="tooltip" data-html="true"
+                        data-original-title="Le Groupe Orange a une forte expertise sur son métier historique des télécoms et le devient aussi sur la partie software. Depuis plusieurs années, Orange investit dans le développement interne de ses produits et services stratégiques pour offrir à nos clients une expérience optimale et innover. Orange est présent en France et dans de nombreux pays en Europe, en Afrique et au Moyen Orient.">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/orange.png" alt="Orange"/></a>
+                    </div>
+                    <div class="single">
+                      <a href="https://fr.bonitasoft.com/" target="_blank">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/bonitasoft.png" alt="BonitSoft"/></a>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="single">
+                      <a href="https://www.exoscale.com" target="_blank">
+                        <img src="{{.Site.BaseURL}}/img/sponsors/2019/exoscale.png" alt="Exoscale"/></a>
+                    </div>
+                  </div>
+                </div>
+                
+                <div class="sponsors-btn-area">
+                  <a class="snc-btn snc-btn-big" href="{{.Site.BaseURL}}{{ .Lang }}/sponsors"><span>Devenir sponsor</span></a>
+                </div>
+    
+                <div class="row">
+                  <div class="col-xs-12">
+                    <h3 class="sponsored-heading">Partenaires</h3>
+                  </div>
+                </div>
+                <div class="sponsors-area">
+                    {{ range $i, $sponsor := $.Site.Data.sponsors.partners }}
+                      {{ if modBool $i 3 }}
+                      <div class="row">
+                      {{end}}
+                          <div class="single">
+                            <a href="{{ $sponsor.url_fr }}" target="_blank"
+                                data-placement="top" data-toggle="tooltip" data-html="true"
+                                data-original-title="{{ $sponsor.description_fr }}">
+                              <img src="{{.Site.BaseURL}}/{{ $sponsor.logo }}" alt="{{ $sponsor.name }}"/></a>
+                          </div>
+                      {{ if modBool (add $i 1) 3 }}
+                      </div>
+                      {{end}}                  
+                    {{ end }}
+                </div>
+              </div> <!-- Container -->
+            </div><!-- Inner -->
+          </div> <!-- Inner-bg -->
+        </div> <!-- Sponsors -->
+      </section>
+  
+  <section>
+    <div id="venue" class="snc-venue">
+      <div class="snc-inner">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12">
+              <div class="snc-heading-area">
+                <h2 class="snc-heading">
+                  <span class="back-heading">
+                      <i class="fa fa-map-o" aria-hidden="true"></i>
+                  </span>
+                  <span class="heading">Venir</span>
+                </h2>
+                <p class="text">
+                  SnowCamp se déroulera au Centre de Congrès du WTC (World Trade Center) de Grenoble à la fois pour les Universités et les Conférences.
+                </p>
+              </div>
             </div>
           </div>
-          <div class="col-xs-12 col-sm-6 col-md-6 polaroid-images">
-            <div class="single">
-              <a href="http://www.congres-wtcgrenoble.com/sites/default/files/PLAN%20ACCES%20GENERAL.pdf" target="_blank" class="rot4" title="WTC - Plan d'accès">
-                <img src="{{.Site.BaseURL}}/img/wtc-access-en.png" alt="WTC, Centre de Congrès de Grenoble" width="30%">
-              </a>
+          <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-6 polaroid-images">
+              <div class="single">
+                <a href="http://www.congres-wtcgrenoble.com/fr/annuaire-geolocalise?field_service_tid%5B%5D=73&field_service_tid%5B%5D=69&field_service_tid%5B%5D=68&field_service_tid%5B%5D=70" target="_blank" class="rot-4" title="WTC Grenoble">
+                  <img src="{{.Site.BaseURL}}/img/wtc.jpg" alt="WTC Grenoble" width="40%">
+                </a>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-6 col-md-6">
+              <div class="single">
+                <p>Les Universités et les Conférences auront toutes lieux à la
+                  <a href="http://www.congres-wtcgrenoble.com/fr" target="_blank"><strong>"WTC World Trade Center Grenoble"</strong></a>,
+                   un Centre de Conférences au cœur de Grenoble.</p>
+                <br/>
+                <p><strong>5 - 7 , place Robert Schuman<br/>38025 Grenoble</strong></p>
+                <br/>
+                <p>Vous pouvez y accéder :</p>
+                <ul>
+                  <li>par la ligne B du Tram (direction Grenoble Presqu'île), arrêt "Palais De Justice - Gare"</li>
+                  <li>en voiture (vous pouvez vous garer aux parkings Doyen Weil ou d'Europole Gare)
+                    <ul>
+                      <li>en arrivant de Lyon ou de Valence, prenez la sortie d’autoroute "Europole - Gares" et suivre la direction Europole</li>
+                      <li>en arrivant de Chambéry, Gap ou Sisteron, prenez la rocade sud, suivre la direction Lyon par l’autoroute, puis la
+                        sortie "Europole - Gares" et suivre la direction Europole</li>
+                    </ul>
+                  </li>
+                  <li>en train ou bus : utilisez le passage souterrain depuis la gare vers Europole</li>
+                  <li>par avion : il y a des navettes d'aéroports : depuis Lyon Saint-Exupéry (17 rotations
+                    7j/7) et depuis Genève Cointrin (3 rotations, 7j/7)</li>
+                  <li>en <a href="http://www.metromobilite.fr/velo.html" target="_blank">vélo</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-6">
+              <div class="single">
+                <p><strong>Latitude :</strong> 45.191113</p>
+                <p><strong>Longitude :</strong> 5.712145</p>
+              </div>
+              <div class="single">
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2811.812207884478!2d5.711009615420941!3d45.190897559659334!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478af481b7661f97%3A0x2f475fe8d95f61e0!2sCentre+de+congr%C3%A8s+du+World+Trade+Center+Grenoble!5e0!3m2!1sfr!2sfr!4v1555137908940!5m2!1sfr!2sfr" width="500" height="400" frameborder="0" style="border:0" allowfullscreen></iframe>
+              </div>
+              <div class="single polaroid-images">
+                <a href="#" target="_blank" class="rot-4" title="WTC - Atrium (Crédit photo WTC)">
+                  <img src="{{.Site.BaseURL}}/img/wtc-atrium.jpg" alt="WTC - Atrium (Crédit photo WTC)" width="40%">
+                </a>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-6 col-md-6 polaroid-images">
+              <div class="single">
+                <a href="http://www.congres-wtcgrenoble.com/sites/default/files/PLAN%20ACCES%20GENERAL.pdf" target="_blank" class="rot4" title="WTC - Plan d'accès">
+                  <img src="{{.Site.BaseURL}}/img/wtc-access-en.png" alt="WTC, Centre de Congrès de Grenoble" width="30%">
+                </a>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+  


### PR DESCRIPTION
-  refactor: use template for the sponsors section. Now, the sponsors
data (logo, url, description, etc.) are declared in a `sponsors.yml`
and the rendering is done via gohugo templating