### PR TITLE
Resolve deploy issue due to obsolete ubuntu version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   merge_schedule:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:


### PR DESCRIPTION
The deploy workflow was failing for me due to an obsoleted version of Ubuntu.
Changed the version to ubuntu-latest to prevent further deployment issues